### PR TITLE
Update Makefile with right extension from README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ modpack: out/main.o out/protracker.o out/player61a.o out/log.o out/buffer.o out/
 out/%.o: src/%.c
 	$(CC) -c -o $@ $(CCFLAGS) $<
 
-out/readme.h: README.md
+out/readme.h: README.txt
 	cat $< | tr "\`" " " | xxd -i > $@
 
 SHARED_HEADERS=src/buffer.h src/log.h src/options.h


### PR DESCRIPTION
Makefile wasn't changed in commit 86e343c (Rename README.md to README.txt)